### PR TITLE
Getting information about keys not found due to redis availability error

### DIFF
--- a/pool_test.go
+++ b/pool_test.go
@@ -1832,10 +1832,13 @@ var _ = Describe("Pool_GD", func() {
 				Expect(statuses[0].Err()).NotTo(HaveOccurred())
 				Expect(statuses[1].Err()).To(Equal(errors.New("EOF")))
 				mgetKeys := append(keys, "e3")
-				vals, err := pool.MGetWithGD(context.Background(), mgetKeys...)
+				vals, keyErrors := pool.MGetWithGD(context.Background(), mgetKeys...)
 				time.Sleep(10 * time.Millisecond)
-				Expect(err).To(Equal(errors.New("EOF")))
 				Expect(vals).To(Equal([]interface{}{nil, "b3", nil, "d3", nil}))
+				Expect(keyErrors).To(Equal(map[string]error{
+					"a3": errors.New("EOF"),
+					"c3": errors.New("EOF"),
+				}))
 				pool.Del(keys...)
 			}
 		})


### PR DESCRIPTION
It is correct to write to the cache only those keys that do not really exist. If the shard was unavailable when reading the key, then it would be good to know this information so as not to create a spurious write to a non-working shard.