### PR TITLE
Add get master shards method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## v3.3.2 (2025-14-04)
+
+- Add ExpireNX, ExpireXX, ExpireGT, ExpireLT methods
+
 ## v3.3.1 (2024-22-07)
 
 - Add ExpireNX, ExpireXX, ExpireGT, ExpireLT methods

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## v3.3.2 (2025-14-04)
 
-- Add ExpireNX, ExpireXX, ExpireGT, ExpireLT methods
+- Add GetMasterShards method
 
 ## v3.3.1 (2024-22-07)
 

--- a/pool.go
+++ b/pool.go
@@ -199,6 +199,20 @@ func (p *Pool) WithMasterShards(keys ...string) (map[*redis.Client][]string, err
 	return mapClients, nil
 }
 
+// GetMasterShards returns master connects for shards
+func (p *Pool) GetMasterShards() ([]*redis.Client, error) {
+	if factory, ok := p.connFactory.(*ShardConnFactory); ok {
+		clients := make([]*redis.Client, 0, len(factory.shards))
+		for _, shard := range factory.shards {
+			conn, _ := shard.getMasterConn()
+			clients = append(clients, conn)
+		}
+		return clients, nil
+	}
+	conn, _ := p.connFactory.getMasterConn()
+	return []*redis.Client{conn}, nil
+}
+
 // Pipeline returns pipeline for HA configuration, to get a pipeline for shards use WithMasterShards
 func (p *Pool) Pipeline() (redis.Pipeliner, error) {
 	if _, ok := p.connFactory.(*ShardConnFactory); ok {

--- a/pool_test.go
+++ b/pool_test.go
@@ -1928,6 +1928,21 @@ var _ = Describe("Pool", func() {
 				Expect(int(nAfter)).To(Equal(0))
 			}
 		})
+
+		It("GetMasterShards", func() {
+			var (
+				shards []*redis.Client
+				err    error
+			)
+
+			shards, err = haPool.GetMasterShards()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(len(shards)).To(Equal(1))
+
+			shards, err = shardPool.GetMasterShards()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(len(shards)).To(Equal(2))
+		})
 	})
 })
 


### PR DESCRIPTION
Hello! I want to store a service's preferences (a single key-value pair) in a redis storage, which is sharded. For better control, it would be nice to choose a specific shard manually. At first, I thought about updating the `WithMasterShards` method by removing the `errWrongNumberValuesArguments` error, but that would break backward compatibility. So, I added a new method instead.